### PR TITLE
Fix cgranade.com website link

### DIFF
--- a/books.md
+++ b/books.md
@@ -10,7 +10,7 @@ title: Books
     </div>
     <div style="flex-direction: column; flex-basis: 100%; flex: 2;">
       <p>
-        <a href="https://www.manning.com/books/learn-quantum-computing-with-python-and-q-sharp" target="_top">Learn Quantum Computing with Python and Q#</a> with <a href="https://cgranade.com/">Chris Granade</a>
+        <a href="https://www.manning.com/books/learn-quantum-computing-with-python-and-q-sharp" target="_top">Learn Quantum Computing with Python and Q#</a> with <a href="https://www.cgranade.com/">Chris Granade</a>
       </p>
     </div>
     <div style="flex-direction: column; flex-basis: 100%; flex: 1; margin: 0.4em;">


### PR DESCRIPTION
The following all redirect correctly to the website, but unfortunately https://cgranade.com doesn't, and this commit adds the necessary "www." prefix:
- http://www.cgranade.com
- http://cgranade.com
- https://www.cgranade.com